### PR TITLE
Inhibit saving state when testing

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -14,6 +14,8 @@ public class Terminal.Application : Gtk.Application {
     public static GLib.Settings settings;
     public static GLib.Settings settings_sys;
 
+    public bool is_testing { get; set construct; }
+
     private static Themes themes;
 
     public Application () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1357,6 +1357,11 @@ namespace Terminal {
             string[] opened_tabs = {};
             int focused_tab = 0;
 
+            // Continuous saving of opened terminals interferes with current unit tests
+            if (app.is_testing) {
+                return;
+            }
+
             if (save_zooms && current_terminal != null) {
                 Application.saved_state.set_double ("zoom", current_terminal.font_scale);
             }

--- a/src/tests/Application.vala
+++ b/src/tests/Application.vala
@@ -12,7 +12,8 @@ namespace Terminal.Test.Application {
 
     private void setup () {
         application = new Terminal.Application () {
-            application_id = "io.elementary.terminal.tests.application"
+            application_id = "io.elementary.terminal.tests.application",
+            is_testing = true
         };
 
         application.shutdown.connect (() => application.get_windows ().foreach ((win) => win.destroy ()));


### PR DESCRIPTION
A simple fix to allow current commandline unit tests to pass without alteration.